### PR TITLE
Remove call to PlayerEvent.ItemCrafted

### DIFF
--- a/src/main/java/com/ewyboy/ewysworkshop/page/unit/UnitCrafting.java
+++ b/src/main/java/com/ewyboy/ewysworkshop/page/unit/UnitCrafting.java
@@ -106,12 +106,6 @@ public class UnitCrafting extends Unit {
 
         Item item = itemStack.getItem();
 
-        try {
-            FMLCommonHandler.instance().firePlayerCraftingEvent(player, itemStack, inventoryCrafting);
-        } catch (Exception ex) {
-            if (ConfigLoader.debugMode) ex.printStackTrace();
-        }
-
         if(player != null) {
             player.addStat(StatList.objectCraftStats[Item.getIdFromItem(item)], itemStack.stackSize);
         }


### PR DESCRIPTION
This really spams server log when autocrafting as VSWE passed null to
the event and some mods do player.something() in their event
handlers/ASMs.
And actually calling Player ItemCrafted doesn't make sense for autocrafting, unless you make your own FakePlayer, which I don't think is strictly necessary.
